### PR TITLE
Telefonbuch und TR-064-Konfiguration

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,6 +4,10 @@ ioBroker fritzbox Adapter
 
 
 ## Changelog
+### 0.3.1 (2016-07-24)
+* (BasGo) enhanced TR-064 configuration
+* (BasGo) added rudimentary phonebook download into object store
+
 ### 0.3.0 (2015-06-26)
 * (UncleSamSwiss) added support for wlan.enabled (using TR-064)
 
@@ -75,6 +79,8 @@ Unter **fritzbox.x.** legt der Adapter folgende Channel und Datenpunkte an:
 * **wlan.                                   (CHANNEL)**
 * wlan.enabled                            (true/false, read & write, Zustand des WLANs, nur verfügbar wenn Passwort konfiguriert ist)
 
+* **phonebook.                              (CHANNEL)**
+* phonebook.tableJSON                     (Telefonbuch aller externen Nummern als JSON)
 
 ## Beispiel-Widgets
 

--- a/admin/index.html
+++ b/admin/index.html
@@ -252,7 +252,7 @@
     <h4>TR-064</h4>
     <table>
         <tr>
-            <td colspan="2" class="translate"><p>tr064 disclaimer</p></td>
+            <td colspan="2" class="translate">tr064 disclaimer</td>
         </tr>
         <tr>
             <td class="translate">Username:</td>

--- a/admin/index.html
+++ b/admin/index.html
@@ -31,9 +31,10 @@
         "fritzbox adapter settings": {"en": "Fritzbox Configuration",         "de": "Fritzbox Adapter-Einstellungen",        "ru": "Fritzbox Configuration"},
         "fritzbox ip address":       {"en": "Fritzbox IP-Address",            "de": "IP-Adresse der Fritzbox",               "ru": "Fritzbox IP-Address"},
         "numbers":                   {"en": "Numbers",                        "de": "Rufnummern",                            "ru": "Numbers"},
+        "Username:":                 {"en": "Username:",                      "de": "Benutzer:",                             "ru": "Username:"},
         "IP-Adresse:":               {"en": "IP-Address:",                    "de": "IP-Adresse:",                           "ru": "IP-Address:"},
-        "password":                  {"en": "Password*:",                     "de": "Passwort*:",                            "ru": "Password*:"},
-        "password-disclaimer":       {"en": "* The password is only required if you wish to get additional information (Wi-Fi). Please be aware that the password is stored in plain-text in ioBroker!",
+        "Password:":                 {"en": "Password*:",                     "de": "Passwort*:",                            "ru": "Password*:"},
+        "Password-Disclaimer":       {"en": "* The password is only required if you wish to get additional information (Wi-Fi). Please be aware that the password is stored in plain-text in ioBroker!",
                                       "de": "* Das Passwort wird nur benötigt, wenn zusätzliche Informationen (WLAN) gewünscht sind. Bitte beachten: das Passwort wird in Klartext in ioBroker gespeichert!",
                                       "ru": "* The password is only required if you wish to get additional information (Wi-Fi). Please be aware that the password is stored in plain-text in ioBroker!"},
         "country code":              {"en": "Country Code:",                  "de": "Landesvorwahl ohne Präfix (z.B.: 49):", "ru": "Country Code:"},
@@ -246,11 +247,15 @@
             <td><input type="text" id="fritzboxAddress" class="value"/></td>
         </tr>
         <tr>
-            <td class="translate">password</td>
+            <td class="translate">Username:</td>
+            <td><input type="text" id="fritzboxUser" class="value" /></td>
+        </tr>
+        <tr>
+            <td class="translate">Password:</td>
             <td><input type="password" id="fritzboxPassword" class="value" /></td>
         </tr>
         <tr>
-            <td colspan="2" class="translate">password-disclaimer</td>
+            <td colspan="2" class="translate">Password-Disclaimer:</td>
         </tr>
     </table>
     <h4 class="translate">numbers</h4>

--- a/admin/index.html
+++ b/admin/index.html
@@ -30,14 +30,15 @@
     systemDictionary = {
         "fritzbox adapter settings": {"en": "Fritzbox Configuration",         "de": "Fritzbox Adapter-Einstellungen",        "ru": "Fritzbox Configuration"},
         "fritzbox ip address":       {"en": "Fritzbox IP-Address",            "de": "IP-Adresse der Fritzbox",               "ru": "Fritzbox IP-Address"},
-        "fritzbox credentials":      {"en": "Fritzbox Credentials",           "de": "Zugangsdaten",                          "ru": "Fritzbox Credentials" },
         "numbers":                   {"en": "Numbers",                        "de": "Rufnummern",                            "ru": "Numbers"},
         "Username:":                 {"en": "Username:",                      "de": "Benutzer:",                             "ru": "Username:"},
         "IP-Adresse:":               {"en": "IP-Address:",                    "de": "IP-Adresse:",                           "ru": "IP-Address:"},
-        "Password:":                 {"en": "Password:",                     "de": "Passwort:",                            "ru": "Password:"},
-        "Credential-Disclaimer":     {"en": "* The credentials are only required if you wish to get additional information (Wi-Fi, phonebook). Please be aware that the password is stored in plain-text in ioBroker!",
-                                      "de": "* Die Zugangsdaten werden nur benötigt, wenn zusätzliche Informationen (WLAN, Telefonbuch) aktiviert werden sollen. Bitte beachten: das Passwort wird in Klartext in ioBroker gespeichert!",
-                                      "ru": "* The credentials are only required if you wish to get additional information (Wi-Fi, phonebook). Please be aware that the password is stored in plain-text in ioBroker!"},
+        "Password:":                 {"en": "Password:",                      "de": "Passwort:",                            "ru": "Password:"},
+        "tr064 disclaimer":          {"en": "The credentials are only required if you wish to get additional functionality (Wi-Fi, phonebook). Please be aware that the password is stored in plain-text in ioBroker!",
+                                      "de": "Die Zugangsdaten werden nur benötigt, wenn zusätzliche Funktionalitäten (WLAN, Telefonbuch) aktiviert werden sollen. Bitte beachten: das Passwort wird in Klartext in ioBroker gespeichert!",
+                                      "ru": "The credentials are only required if you wish to get additional functionality (Wi-Fi, phonebook). Please be aware that the password is stored in plain-text in ioBroker!"},
+        "tr064 enable wlan":         { "en": "Control WLAN",                  "de": "WLAN-Steuerung:",                       "ru": "Control WLAN" },
+        "tr064 enable phonebook":    { "en": "Read phonebook",                "de": "Telefonbuch auslesen:",                 "ru": "Read phonebook" },
         "country code":              {"en": "Country Code:",                  "de": "Landesvorwahl ohne Präfix (z.B.: 49):", "ru": "Country Code:"},
         "area code":                 {"en": "Area Code:",                     "de": "Ortsvorwahl ohne Präfix (z.B.: 211):",  "ru": "Area Code:"},
         "unknown number":            {"en": "Unknown number:",                "de": "Unterdrückte/unbekannte Rufnummer:",    "ru": "Unknown number:"},
@@ -248,18 +249,26 @@
             <td><input type="text" id="fritzboxAddress" class="value"/></td>
         </tr>
     </table>
-    <h4 class="translate">fritzbox credentials</h4>
+    <h4>TR-064</h4>
     <table>
         <tr>
+            <td colspan="2" class="translate"><p>tr064 disclaimer</p></td>
+        </tr>
+        <tr>
             <td class="translate">Username:</td>
-            <td><input type="text" id="fritzboxUser" class="value" /></td>
+            <td><input type="text" id="fritzboxUser" class="value"/></td>
         </tr>
         <tr>
             <td class="translate">Password:</td>
-            <td><input type="password" id="fritzboxPassword" class="value" /></td>
+            <td><input type="password" id="fritzboxPassword" class="value"/></td>
         </tr>
         <tr>
-            <td colspan="2" class="translate">Credential-Disclaimer</td>
+            <td class="translate">tr064 enable wlan</td>
+            <td><input id="enableWlan" type="checkbox" class="value" /></td>
+        </tr>
+        <tr>
+            <td class="translate">tr064 enable phonebook</td>
+            <td><input id="enablePhonebook" type="checkbox" class="value" /></td>
         </tr>
     </table>
     <h4 class="translate">numbers</h4>

--- a/admin/index.html
+++ b/admin/index.html
@@ -30,13 +30,14 @@
     systemDictionary = {
         "fritzbox adapter settings": {"en": "Fritzbox Configuration",         "de": "Fritzbox Adapter-Einstellungen",        "ru": "Fritzbox Configuration"},
         "fritzbox ip address":       {"en": "Fritzbox IP-Address",            "de": "IP-Adresse der Fritzbox",               "ru": "Fritzbox IP-Address"},
+        "fritzbox credentials":      {"en": "Fritzbox Credentials",           "de": "Zugangsdaten",                          "ru": "Fritzbox Credentials" },
         "numbers":                   {"en": "Numbers",                        "de": "Rufnummern",                            "ru": "Numbers"},
         "Username:":                 {"en": "Username:",                      "de": "Benutzer:",                             "ru": "Username:"},
         "IP-Adresse:":               {"en": "IP-Address:",                    "de": "IP-Adresse:",                           "ru": "IP-Address:"},
-        "Password:":                 {"en": "Password*:",                     "de": "Passwort*:",                            "ru": "Password*:"},
-        "Password-Disclaimer":       {"en": "* The password is only required if you wish to get additional information (Wi-Fi). Please be aware that the password is stored in plain-text in ioBroker!",
-                                      "de": "* Das Passwort wird nur benötigt, wenn zusätzliche Informationen (WLAN) gewünscht sind. Bitte beachten: das Passwort wird in Klartext in ioBroker gespeichert!",
-                                      "ru": "* The password is only required if you wish to get additional information (Wi-Fi). Please be aware that the password is stored in plain-text in ioBroker!"},
+        "Password:":                 {"en": "Password:",                     "de": "Passwort:",                            "ru": "Password:"},
+        "Credential-Disclaimer":     {"en": "* The credentials are only required if you wish to get additional information (Wi-Fi, phonebook). Please be aware that the password is stored in plain-text in ioBroker!",
+                                      "de": "* Die Zugangsdaten werden nur benötigt, wenn zusätzliche Informationen (WLAN, Telefonbuch) aktiviert werden sollen. Bitte beachten: das Passwort wird in Klartext in ioBroker gespeichert!",
+                                      "ru": "* The credentials are only required if you wish to get additional information (Wi-Fi, phonebook). Please be aware that the password is stored in plain-text in ioBroker!"},
         "country code":              {"en": "Country Code:",                  "de": "Landesvorwahl ohne Präfix (z.B.: 49):", "ru": "Country Code:"},
         "area code":                 {"en": "Area Code:",                     "de": "Ortsvorwahl ohne Präfix (z.B.: 211):",  "ru": "Area Code:"},
         "unknown number":            {"en": "Unknown number:",                "de": "Unterdrückte/unbekannte Rufnummer:",    "ru": "Unknown number:"},
@@ -246,6 +247,9 @@
             <td class="translate">IP-Adresse:</td>
             <td><input type="text" id="fritzboxAddress" class="value"/></td>
         </tr>
+    </table>
+    <h4 class="translate">fritzbox credentials</h4>
+    <table>
         <tr>
             <td class="translate">Username:</td>
             <td><input type="text" id="fritzboxUser" class="value" /></td>
@@ -255,7 +259,7 @@
             <td><input type="password" id="fritzboxPassword" class="value" /></td>
         </tr>
         <tr>
-            <td colspan="2" class="translate">Password-Disclaimer:</td>
+            <td colspan="2" class="translate">Credential-Disclaimer</td>
         </tr>
     </table>
     <h4 class="translate">numbers</h4>

--- a/io-package.json
+++ b/io-package.json
@@ -69,7 +69,7 @@
         "write": false,
         "desc": "last message from fritzbox as string"
       },
-      "native": {}
+      "native": { }
     },
     {
       "_id": "calls",
@@ -78,7 +78,7 @@
         "name": "calls",
         "role": "call info"
       },
-      "native": {}
+      "native": { }
     },
     {
       "_id": "calls.ring",
@@ -91,7 +91,7 @@
         "write": false,
         "desc": "ring activ?"
       },
-      "native": {}
+      "native": { }
     },
     {
       "_id": "calls.missedCount",
@@ -104,7 +104,7 @@
         "write": true,
         "desc": "Counter: rings missed"
       },
-      "native": {}
+      "native": { }
     },
     {
       "_id": "calls.missedDateReset",
@@ -117,7 +117,7 @@
         "write": true,
         "desc": "date last reset: counter rings missed"
       },
-      "native": {}
+      "native": { }
     },
     {
       "_id": "calls.ringActualNumber",
@@ -130,7 +130,7 @@
         "write": false,
         "desc": "actual last ringing number"
       },
-      "native": {}
+      "native": { }
     },
     {
       "_id": "calls.ringActualNumbers",
@@ -143,7 +143,7 @@
         "write": false,
         "desc": "actual ringing numbers"
       },
-      "native": {}
+      "native": { }
     },
     {
       "_id": "calls.ringLastNumber",
@@ -156,7 +156,7 @@
         "write": false,
         "desc": "ring last number"
       },
-      "native": {}
+      "native": { }
     },
     {
       "_id": "calls.ringLastMissedNumber",
@@ -169,7 +169,7 @@
         "write": false,
         "desc": "ring last missed number"
       },
-      "native": {}
+      "native": { }
     },
     {
       "_id": "calls.callLastNumber",
@@ -182,7 +182,7 @@
         "write": false,
         "desc": "call last number"
       },
-      "native": {}
+      "native": { }
     },
     {
       "_id": "calls.connectNumber",
@@ -195,7 +195,7 @@
         "write": false,
         "desc": "actual last connected number"
       },
-      "native": {}
+      "native": { }
     },
     {
       "_id": "calls.connectNumbers",
@@ -208,7 +208,7 @@
         "write": false,
         "desc": "actual last connected numbers"
       },
-      "native": {}
+      "native": { }
     },
     {
       "_id": "calls.counterActualCalls",
@@ -217,7 +217,7 @@
         "name": "calls",
         "role": "call info"
       },
-      "native": {}
+      "native": { }
     },
     {
       "_id": "calls.counterActualCalls.allActiveCount",
@@ -230,7 +230,7 @@
         "write": false,
         "desc": "Counter: all active Calls"
       },
-      "native": {}
+      "native": { }
     },
     {
       "_id": "calls.counterActualCalls.connectCount",
@@ -243,7 +243,7 @@
         "write": false,
         "desc": "Counter: actual activ connected calls"
       },
-      "native": {}
+      "native": { }
     },
     {
       "_id": "calls.counterActualCalls.ringCount",
@@ -256,7 +256,7 @@
         "write": false,
         "desc": "Counter: actual ring"
       },
-      "native": {}
+      "native": { }
     },
     {
       "_id": "calls.counterActualCalls.callCount",
@@ -269,7 +269,7 @@
         "write": false,
         "desc": "Counter: actual activ calls"
       },
-      "native": {}
+      "native": { }
     },
     {
       "_id": "calls.telLinks",
@@ -278,7 +278,7 @@
         "name": "calls",
         "role": "call info"
       },
-      "native": {}
+      "native": { }
     },
     {
       "_id": "calls.telLinks.ringLastNumberTel",
@@ -291,7 +291,7 @@
         "write": false,
         "desc": "letzter Anrufer als tel:link"
       },
-      "native": {}
+      "native": { }
     },
     {
       "_id": "calls.telLinks.callLastNumberTel",
@@ -304,7 +304,7 @@
         "write": false,
         "desc": "letzte angerufene Nummer (Wahlwiederholung) als tel:link"
       },
-      "native": {}
+      "native": { }
     },
     {
       "_id": "calls.telLinks.ringLastMissedNumberTel",
@@ -317,7 +317,7 @@
         "write": false,
         "desc": "letzter verpasster Anrufer als tel:link"
       },
-      "native": {}
+      "native": { }
     },
     {
       "_id": "callmonitor",
@@ -326,7 +326,7 @@
         "name": "callmonitor",
         "role": "callmonitor"
       },
-      "native": {}
+      "native": { }
     },
     {
       "_id": "callmonitor.all",
@@ -339,7 +339,7 @@
         "write": false,
         "desc": "callmonitor all"
       },
-      "native": {}
+      "native": { }
     },
     {
       "_id": "callmonitor.ring",
@@ -352,7 +352,7 @@
         "write": false,
         "desc": "callmonitor ring"
       },
-      "native": {}
+      "native": { }
     },
     {
       "_id": "callmonitor.call",
@@ -365,7 +365,7 @@
         "write": false,
         "desc": "callmonitor call"
       },
-      "native": {}
+      "native": { }
     },
     {
       "_id": "callmonitor.connect",
@@ -378,7 +378,7 @@
         "write": false,
         "desc": "callmonitor connect"
       },
-      "native": {}
+      "native": { }
     },
     {
       "_id": "system",
@@ -387,7 +387,7 @@
         "name": "system",
         "role": "system"
       },
-      "native": {}
+      "native": { }
     },
     {
       "_id": "system.deltaTime",
@@ -400,7 +400,7 @@
         "write": false,
         "desc": "delta time in seconds between fritzbox and ioBroker"
       },
-      "native": {}
+      "native": { }
     },
     {
       "_id": "system.deltaTimeOK",
@@ -413,7 +413,7 @@
         "write": false,
         "desc": "delta time in seconds between fritzbox and ioBroker ok"
       },
-      "native": {}
+      "native": { }
     },
     {
       "_id": "cdr",
@@ -422,7 +422,7 @@
         "name": "cdr",
         "role": "cdr"
       },
-      "native": {}
+      "native": { }
     },
     {
       "_id": "cdr.json",
@@ -435,7 +435,7 @@
         "write": false,
         "desc": "call cdr as JSON"
       },
-      "native": {}
+      "native": { }
     },
     {
       "_id": "cdr.html",
@@ -448,7 +448,7 @@
         "write": false,
         "desc": "call cdr as html"
       },
-      "native": {}
+      "native": { }
     },
     {
       "_id": "cdr.missedJSON",
@@ -461,7 +461,7 @@
         "write": false,
         "desc": "missed calls as JSON"
       },
-      "native": {}
+      "native": { }
     },
     {
       "_id": "cdr.missedHTML",
@@ -474,7 +474,7 @@
         "write": false,
         "desc": "missed calls as HTML"
       },
-      "native": {}
+      "native": { }
     },
     {
       "_id": "cdr.txt",
@@ -487,7 +487,7 @@
         "write": false,
         "desc": "call cdr as txt"
       },
-      "native": {}
+      "native": { }
     },
     {
       "_id": "history",
@@ -496,7 +496,7 @@
         "name": "history",
         "role": "history"
       },
-      "native": {}
+      "native": { }
     },
     {
       "_id": "history.allTableHTML",
@@ -509,7 +509,7 @@
         "write": false,
         "desc": "history of calls as HTML"
       },
-      "native": {}
+      "native": { }
     },
     {
       "_id": "history.allTableTxt",
@@ -522,7 +522,7 @@
         "write": false,
         "desc": "history of calls as Txt"
       },
-      "native": {}
+      "native": { }
     },
     {
       "_id": "history.allTableJSON",
@@ -535,7 +535,7 @@
         "write": false,
         "desc": "history of calls as JSON"
       },
-      "native": {}
+      "native": { }
     },
     {
       "_id": "history.missedTableHTML",
@@ -548,7 +548,7 @@
         "write": false,
         "desc": "history of missed calls as HTML"
       },
-      "native": {}
+      "native": { }
     },
     {
       "_id": "history.missedTableJSON",
@@ -564,6 +564,28 @@
       "native": {}
     },
     {
+      "_id": "phonebook",
+      "type": "channel",
+      "common": {
+        "name": "phonebook",
+        "role": "phonebook"
+      },
+      "native": { }
+    },
+    {
+      "_id": "phonebook.tableJSON",
+      "type": "state",
+      "common": {
+        "name": "phonebook as JSON",
+        "type": "string",
+        "role": "phonebook",
+        "read": true,
+        "write": false,
+        "desc": "phonebook as JSON"
+      },
+      "native": {}
+    },
+    {
       "_id": "wlan.enabled",
       "type": "state",
       "common": {
@@ -574,7 +596,7 @@
         "write": true,
         "desc": "Wi-Fi (WLAN) enabled"
       },
-      "native": {}
+      "native": { }
     }
 
   ]

--- a/io-package.json
+++ b/io-package.json
@@ -69,7 +69,7 @@
         "write": false,
         "desc": "last message from fritzbox as string"
       },
-      "native": { }
+      "native": {}
     },
     {
       "_id": "calls",
@@ -78,7 +78,7 @@
         "name": "calls",
         "role": "call info"
       },
-      "native": { }
+      "native": {}
     },
     {
       "_id": "calls.ring",
@@ -91,7 +91,7 @@
         "write": false,
         "desc": "ring activ?"
       },
-      "native": { }
+      "native": {}
     },
     {
       "_id": "calls.missedCount",
@@ -104,7 +104,7 @@
         "write": true,
         "desc": "Counter: rings missed"
       },
-      "native": { }
+      "native": {}
     },
     {
       "_id": "calls.missedDateReset",
@@ -117,7 +117,7 @@
         "write": true,
         "desc": "date last reset: counter rings missed"
       },
-      "native": { }
+      "native": {}
     },
     {
       "_id": "calls.ringActualNumber",
@@ -130,7 +130,7 @@
         "write": false,
         "desc": "actual last ringing number"
       },
-      "native": { }
+      "native": {}
     },
     {
       "_id": "calls.ringActualNumbers",
@@ -143,7 +143,7 @@
         "write": false,
         "desc": "actual ringing numbers"
       },
-      "native": { }
+      "native": {}
     },
     {
       "_id": "calls.ringLastNumber",
@@ -156,7 +156,7 @@
         "write": false,
         "desc": "ring last number"
       },
-      "native": { }
+      "native": {}
     },
     {
       "_id": "calls.ringLastMissedNumber",
@@ -169,7 +169,7 @@
         "write": false,
         "desc": "ring last missed number"
       },
-      "native": { }
+      "native": {}
     },
     {
       "_id": "calls.callLastNumber",
@@ -182,7 +182,7 @@
         "write": false,
         "desc": "call last number"
       },
-      "native": { }
+      "native": {}
     },
     {
       "_id": "calls.connectNumber",
@@ -195,7 +195,7 @@
         "write": false,
         "desc": "actual last connected number"
       },
-      "native": { }
+      "native": {}
     },
     {
       "_id": "calls.connectNumbers",
@@ -208,7 +208,7 @@
         "write": false,
         "desc": "actual last connected numbers"
       },
-      "native": { }
+      "native": {}
     },
     {
       "_id": "calls.counterActualCalls",
@@ -217,7 +217,7 @@
         "name": "calls",
         "role": "call info"
       },
-      "native": { }
+      "native": {}
     },
     {
       "_id": "calls.counterActualCalls.allActiveCount",
@@ -230,7 +230,7 @@
         "write": false,
         "desc": "Counter: all active Calls"
       },
-      "native": { }
+      "native": {}
     },
     {
       "_id": "calls.counterActualCalls.connectCount",
@@ -243,7 +243,7 @@
         "write": false,
         "desc": "Counter: actual activ connected calls"
       },
-      "native": { }
+      "native": {}
     },
     {
       "_id": "calls.counterActualCalls.ringCount",
@@ -256,7 +256,7 @@
         "write": false,
         "desc": "Counter: actual ring"
       },
-      "native": { }
+      "native": {}
     },
     {
       "_id": "calls.counterActualCalls.callCount",
@@ -269,7 +269,7 @@
         "write": false,
         "desc": "Counter: actual activ calls"
       },
-      "native": { }
+      "native": {}
     },
     {
       "_id": "calls.telLinks",
@@ -278,7 +278,7 @@
         "name": "calls",
         "role": "call info"
       },
-      "native": { }
+      "native": {}
     },
     {
       "_id": "calls.telLinks.ringLastNumberTel",
@@ -291,7 +291,7 @@
         "write": false,
         "desc": "letzter Anrufer als tel:link"
       },
-      "native": { }
+      "native": {}
     },
     {
       "_id": "calls.telLinks.callLastNumberTel",
@@ -304,7 +304,7 @@
         "write": false,
         "desc": "letzte angerufene Nummer (Wahlwiederholung) als tel:link"
       },
-      "native": { }
+      "native": {}
     },
     {
       "_id": "calls.telLinks.ringLastMissedNumberTel",
@@ -317,7 +317,7 @@
         "write": false,
         "desc": "letzter verpasster Anrufer als tel:link"
       },
-      "native": { }
+      "native": {}
     },
     {
       "_id": "callmonitor",
@@ -326,7 +326,7 @@
         "name": "callmonitor",
         "role": "callmonitor"
       },
-      "native": { }
+      "native": {}
     },
     {
       "_id": "callmonitor.all",
@@ -339,7 +339,7 @@
         "write": false,
         "desc": "callmonitor all"
       },
-      "native": { }
+      "native": {}
     },
     {
       "_id": "callmonitor.ring",
@@ -352,7 +352,7 @@
         "write": false,
         "desc": "callmonitor ring"
       },
-      "native": { }
+      "native": {}
     },
     {
       "_id": "callmonitor.call",
@@ -365,7 +365,7 @@
         "write": false,
         "desc": "callmonitor call"
       },
-      "native": { }
+      "native": {}
     },
     {
       "_id": "callmonitor.connect",
@@ -378,7 +378,7 @@
         "write": false,
         "desc": "callmonitor connect"
       },
-      "native": { }
+      "native": {}
     },
     {
       "_id": "system",
@@ -387,7 +387,7 @@
         "name": "system",
         "role": "system"
       },
-      "native": { }
+      "native": {}
     },
     {
       "_id": "system.deltaTime",
@@ -400,7 +400,7 @@
         "write": false,
         "desc": "delta time in seconds between fritzbox and ioBroker"
       },
-      "native": { }
+      "native": {}
     },
     {
       "_id": "system.deltaTimeOK",
@@ -413,7 +413,7 @@
         "write": false,
         "desc": "delta time in seconds between fritzbox and ioBroker ok"
       },
-      "native": { }
+      "native": {}
     },
     {
       "_id": "cdr",
@@ -422,7 +422,7 @@
         "name": "cdr",
         "role": "cdr"
       },
-      "native": { }
+      "native": {}
     },
     {
       "_id": "cdr.json",
@@ -435,7 +435,7 @@
         "write": false,
         "desc": "call cdr as JSON"
       },
-      "native": { }
+      "native": {}
     },
     {
       "_id": "cdr.html",
@@ -448,7 +448,7 @@
         "write": false,
         "desc": "call cdr as html"
       },
-      "native": { }
+      "native": {}
     },
     {
       "_id": "cdr.missedJSON",
@@ -461,7 +461,7 @@
         "write": false,
         "desc": "missed calls as JSON"
       },
-      "native": { }
+      "native": {}
     },
     {
       "_id": "cdr.missedHTML",
@@ -474,7 +474,7 @@
         "write": false,
         "desc": "missed calls as HTML"
       },
-      "native": { }
+      "native": {}
     },
     {
       "_id": "cdr.txt",
@@ -487,7 +487,7 @@
         "write": false,
         "desc": "call cdr as txt"
       },
-      "native": { }
+      "native": {}
     },
     {
       "_id": "history",
@@ -496,7 +496,7 @@
         "name": "history",
         "role": "history"
       },
-      "native": { }
+      "native": {}
     },
     {
       "_id": "history.allTableHTML",
@@ -509,7 +509,7 @@
         "write": false,
         "desc": "history of calls as HTML"
       },
-      "native": { }
+      "native": {}
     },
     {
       "_id": "history.allTableTxt",
@@ -522,7 +522,7 @@
         "write": false,
         "desc": "history of calls as Txt"
       },
-      "native": { }
+      "native": {}
     },
     {
       "_id": "history.allTableJSON",
@@ -535,7 +535,7 @@
         "write": false,
         "desc": "history of calls as JSON"
       },
-      "native": { }
+      "native": {}
     },
     {
       "_id": "history.missedTableHTML",
@@ -548,7 +548,7 @@
         "write": false,
         "desc": "history of missed calls as HTML"
       },
-      "native": { }
+      "native": {}
     },
     {
       "_id": "history.missedTableJSON",
@@ -570,7 +570,7 @@
         "name": "phonebook",
         "role": "phonebook"
       },
-      "native": { }
+      "native": {}
     },
     {
       "_id": "phonebook.tableJSON",
@@ -596,8 +596,7 @@
         "write": true,
         "desc": "Wi-Fi (WLAN) enabled"
       },
-      "native": { }
+      "native": {}
     }
-
   ]
 }

--- a/io-package.json
+++ b/io-package.json
@@ -1,7 +1,7 @@
 {
   "common": {
     "name": "fritzbox",
-    "version": "0.3.0",
+    "version": "0.3.1",
     "title": "fritzbox Adapter",
     "desc": {
       "en": "Adapter monitors the call information from Fritzbox via tcp, Port 1012 (Activate call monitor in the Fritzbox with #96*5*)",

--- a/io-package.json
+++ b/io-package.json
@@ -30,6 +30,7 @@
   },
   "native": {
     "fritzboxAddress": "192.168.1.1",
+    "fritzboxUser": "dslf-config",
     "fritzboxPassword": "",
     "cc": "49",
     "ac": "211",

--- a/main.js
+++ b/main.js
@@ -1206,14 +1206,13 @@ function getPhonebook(host, user, password) {
                             if (err) {
                                 adapter.log.warn("TR-064: Error while parsing phonebook content: " + err);
                             } else {
-                                adapter.log.debug("TR-064: Successfully parsed phonebook content, persisting result ...");
-
+                                adapter.log.debug("TR-064: Successfully parsed phonebook content, analyzing result ...");
                                 var phonenumbers = []; // create an empty array for fetching all configured phone numbers from fritzbox
                                 var phonebook = result.phonebooks.phonebook[0];
                                 for (var c = 0; c <= phonebook.contact.length; c++) {
                                     var contact = phonebook.contact[c];
                                     if (typeof contact != 'undefined') {
-                                        var entryName = contact.person[0].realName;
+                                        var entryName = contact.person[0].realName[0];
                                         for (var t = 0; t <= contact.telephony.length; t++) {
                                             var telephony = contact.telephony[t];
                                             if (typeof telephony != 'undefined') {
@@ -1237,6 +1236,7 @@ function getPhonebook(host, user, password) {
                                 }
 
                                 adapter.setState('phonebook.tableJSON', JSON.stringify(phonenumbers), true);
+                                adapter.log.debug("TR-064: Successfully analyzed phonebook results");
                             }
                         });
                     }
@@ -1275,7 +1275,7 @@ function connectToFritzbox(host) {
     socketBox.on('data',  parseData);   // Daten wurden aus der Fritzbox empfangen und dann in der Funktion parseData verarbeitet
     
     if (adapter.config.fritzboxUser && adapter.config.fritzboxPassword && adapter.config.fritzboxPassword.length) {
-        adapter.log.info("try to connect to TR-064: " + host + ":49000");
+        adapter.log.info("Trying to connect to TR-064: " + host + ":49000");
 
         // TR-064-Verbindung bereitstellen (und überprüfen)
         getWlanConfig(host, adapter.config.fritzboxUser, adapter.config.fritzboxPassword, function (result) {
@@ -1288,10 +1288,8 @@ function connectToFritzbox(host) {
             }, 10000);
         });
 
-        // try to get phonebook with a short delay
-        setTimeout(function () {
-            getPhonebook(host, adapter.config.fritzboxUser, adapter.config.fritzboxPassword);
-        }, 3000)
+        // try to get phonebook
+        getPhonebook(host, adapter.config.fritzboxUser, adapter.config.fritzboxPassword);
     }
 }
 

--- a/main.js
+++ b/main.js
@@ -41,6 +41,8 @@ var net =    require('net');    // node-Modul für die tcp/ip Kommunikation
 var tr = require("tr-064");     // node-Modul für die Kommunikation via TR-064 mit der FritzBox
                                 // Beschreibung zu TR-064: http://avm.de/service/schnittstellen/
 
+var request = require("request");
+
 var adapter = utils.adapter('fritzbox');
 
 var call = [];
@@ -1187,7 +1189,7 @@ function setWlanEnabled(host, user, password, enabled) {
 }
 
 function getPhonebook(host, user, password) {
-    connectToTR064(host, password, function (sslDev) {
+    connectToTR064(host, user, password, function (sslDev) {
         var tel = sslDev.services["urn:dslforum-org:service:X_AVM-DE_OnTel:1"];
         adapter.log.debug("TR-064: calling GetPhonebook()");
         tel.actions.GetPhonebook({ NewPhonebookID: '0' }, function (err, ret) {
@@ -1205,6 +1207,7 @@ function getPhonebook(host, user, password) {
                                 adapter.log.warn("TR-064: Parsing error: " + err);
                             } else {
                                 adapter.log.debug("TR-064: Successfully parsed content from uri: " + url);
+                                adapter.setState('phonebook.tableJSON', JSON.stringify(result), true);
                             }
                         });
                     }

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "iobroker.fritzbox",
   "description": "Verarbeitet die Callmontiorinformationen der AVM Fritzbox.",
-  "version": "0.3.0",
+  "version": "0.3.1",
   "author": {
     "name": "ruhr",
     "email": "ruhr@digheim.de"
@@ -14,6 +14,10 @@
     {
       "name": "UncleSam",
       "email": "samuel.weibel@gmail.com"
+    },
+    {
+      "name": "BasGo",
+      "email": "basgo@gmx.de"
     }
   ],
   "homepage": "https://github.com/ruhr70/ioBroker.fritzbox",

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "url": "https://github.com/ruhr70/ioBroker.fritzbox"
   },
   "dependencies": {
+    "request": "^2.72.0",
     "xml2js": "^0.4.9",
     "tr-064": "~0.2.0"
   },


### PR DESCRIPTION
Hi ruhr70 (bzw. Michael?),

ich war mal so frei und habe das Auslesen des Fritzbox-Telefonbuchs in den Adapter integriert. Offen ist nun noch, dass Anrufe - sofern gewünscht - gegen das Telefonbuch geprüft und gefundene Name in deine Listen übernommen werden.

Das Telefonbuch ist als Dictionary wie folgt aufgebaut:

`[{
		"key" : "0221123456",
		"value" : {
			"name" : "Anrufername 1",
			"type" : "work"
		}
	}, {
		"key" : "021199887766",
		"value" : {
			"name" : "Anrufername 2",
			"type" : "home"
		}
	}, {
		"key" : "01572394056",
		"value" : {
			"name" : "Anrufername 3",
			"type" : "mobile"
		}
	}
]`

VG

Bastian